### PR TITLE
Options flow: clear empty fields on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Alla anmärkningsvärda ändringar i projektet kommer att dokumenteras i denna fil.
 
+## [1.2.6] - 2026-04-02
+ 
+### Fixed
+- **Inställningar (Options Flow)**: Åtgärdat en irriterande bugg i inställningsmenyn där det inte gick att ta bort tidsbegränsningar (Time Restrictions) eller "Best Price Spans" efter att de väl satts. Tidigare läste integrationen oavsiktligt in gamla värden om man raderade texten, men nu kan man radera rutorna helt och spara, så töms restriktionerna som tänkt.
+
 ## [1.2.5] - 2026-04-02
  
 ### Fixed

--- a/custom_components/tibber-extended/config_flow.py
+++ b/custom_components/tibber-extended/config_flow.py
@@ -177,7 +177,7 @@ class TibberExtendedOptionsFlow(config_entries.OptionsFlow):
 
             if valid:
                 user_input[CONF_ACCESS_TOKEN] = token
-                
+
                 # Sätt värden till tomma strängar om användaren raderat dem
                 for key in (CONF_RESTRICT_TIME_START, CONF_RESTRICT_TIME_END, CONF_BEST_PRICE_SPANS):
                     if key not in user_input:

--- a/custom_components/tibber-extended/config_flow.py
+++ b/custom_components/tibber-extended/config_flow.py
@@ -177,6 +177,11 @@ class TibberExtendedOptionsFlow(config_entries.OptionsFlow):
 
             if valid:
                 user_input[CONF_ACCESS_TOKEN] = token
+                
+                # Sätt värden till tomma strängar om användaren raderat dem
+                for key in (CONF_RESTRICT_TIME_START, CONF_RESTRICT_TIME_END, CONF_BEST_PRICE_SPANS):
+                    if key not in user_input:
+                        user_input[key] = ""
 
                 # Uppdatera config entry data
                 self.hass.config_entries.async_update_entry(

--- a/custom_components/tibber-extended/manifest.json
+++ b/custom_components/tibber-extended/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/adnansarajlic/tibber-extended/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.2.5"
+  "version": "1.2.6"
 }

--- a/custom_components/tibber-extended/sensor.py
+++ b/custom_components/tibber-extended/sensor.py
@@ -300,7 +300,7 @@ class TibberDataCoordinator(DataUpdateCoordinator):
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
-            "User-Agent": "HomeAssistant/Tibber-Extended (1.2.5)",
+            "User-Agent": "HomeAssistant/Tibber-Extended (1.2.6)",
         }
 
         max_attempts = 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,11 @@ class _CoordinatorEntity:
     def __init__(self, coordinator):
         self.coordinator = coordinator
 
+class _OptionsFlow:
+    """Stub för OptionsFlow."""
+    def async_create_entry(self, title, data):
+        return {"type": "create_entry", "title": title, "data": data}
+
 class _DataUpdateCoordinator:
     def __init__(self, hass, logger, *, name, update_interval):
         self.hass = hass
@@ -72,6 +77,7 @@ sys.modules["homeassistant.helpers.restore_state"] = mock_ha.helpers.restore_sta
 sys.modules["homeassistant.config_entries"] = mock_ha.config_entries
 sys.modules["homeassistant.core"] = mock_ha.core
 sys.modules["homeassistant.exceptions"] = mock_ha.exceptions
+sys.modules["homeassistant.data_entry_flow"] = mock_ha.data_entry_flow
 sys.modules["homeassistant.helpers"] = mock_ha.helpers
 sys.modules["homeassistant.helpers.aiohttp_client"] = mock_ha.helpers.aiohttp_client
 sys.modules["homeassistant.helpers.entity_platform"] = mock_ha.helpers.entity_platform
@@ -91,11 +97,13 @@ mock_ha.helpers.update_coordinator.DataUpdateCoordinator = _DataUpdateCoordinato
 mock_ha.helpers.update_coordinator.UpdateFailed = _UpdateFailed
 mock_ha.helpers.storage.Store = MagicMock()
 mock_ha.const.EntityCategory = MagicMock()
+mock_ha.config_entries.OptionsFlow = _OptionsFlow
 
 mock_ha.util.dt.parse_datetime = isoparse
 mock_ha.util.dt.now = lambda: datetime.now(timezone.utc)
 
 sys.modules["aiohttp"] = MagicMock()
+sys.modules["voluptuous"] = MagicMock()
 
 
 # =============================================================
@@ -129,3 +137,4 @@ def _load_module(name, filename):
 
 _load_module("tibber_extended.sensor", "sensor.py")
 _load_module("tibber_extended.binary_sensor", "binary_sensor.py")
+_load_module("tibber_extended.config_flow", "config_flow.py")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,50 @@
+"""Tester för config_flow.py."""
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from tibber_extended.config_flow import TibberExtendedOptionsFlow
+from tibber_extended.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_RESTRICT_TIME_START,
+    CONF_RESTRICT_TIME_END,
+    CONF_BEST_PRICE_SPANS,
+)
+
+
+@pytest.mark.asyncio
+async def test_options_flow_clears_empty_fields():
+    """Om användaren tömmer tidsrestriktioner i formuläret ska config uppdateras med tomma strängar."""
+    
+    # Skapa mock för config entry (befintlig konfig)
+    mock_entry = MagicMock()
+    mock_entry.data = {
+        CONF_ACCESS_TOKEN: "valid_token",
+        CONF_RESTRICT_TIME_START: "22:00",
+        CONF_RESTRICT_TIME_END: "06:00",
+        CONF_BEST_PRICE_SPANS: "1, 2, 3",
+    }
+    
+    # Initialisera options flow
+    flow = TibberExtendedOptionsFlow(mock_entry)
+    flow.hass = MagicMock()
+    
+    # Mocka token-validering att alltid returnera True
+    flow._validate_token = AsyncMock(return_value=True)
+
+    # Scenariot: Användaren skickar in formuläret men raderar restriktion-raderna.
+    # I HA-formulär rensas fälten helt från 'user_input' dict:en.
+    user_input = {
+        CONF_ACCESS_TOKEN: "valid_token"
+        # Notera: Inga restrict_time-fält närvarande, simulering av tömt formulär
+    }
+
+    result = await flow.async_step_init(user_input=user_input)
+    assert result["type"] == "create_entry"
+    
+    # Kontrollera vad som HA sparar. '_config_entry.data' MÅSTE ha tomma strängar
+    call_kwargs = flow.hass.config_entries.async_update_entry.call_args.kwargs
+    new_data = call_kwargs["data"]
+
+    # Dessa fält var raderade, och BUG FIXEN ska säkerställa att de blev ""
+    assert new_data[CONF_RESTRICT_TIME_START] == ""
+    assert new_data[CONF_RESTRICT_TIME_END] == ""
+    assert new_data[CONF_BEST_PRICE_SPANS] == ""


### PR DESCRIPTION
Fix options flow so fields removed by the user are saved as empty strings. If CONF_RESTRICT_TIME_START, CONF_RESTRICT_TIME_END or CONF_BEST_PRICE_SPANS are missing from user_input they are now set to "" before updating the config entry. Added a unit test (tests/test_config_flow.py) and test helpers (tests/conftest.py) to cover this behavior. Also bumped integration version and User-Agent to 1.2.6 and added a changelog entry documenting the fix.