### PR TITLE
Add Recalculate Best Price button and option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Alla anmärkningsvärda ändringar i projektet kommer att dokumenteras i denna fil.
 
+## [1.2.7] - 2026-04-03
+ 
+### Added
+- **Ny knapp: Re-calculate Best Price**: En ny knapp-entitet har lagts till som låter dig tvinga fram en omedelbar omräkning av alla Best Price-fönster utan att vänta på nästa polling eller tidsschema.
+- **Checkruta i inställningar**: Lagt till "Tvinga omräkning vid Spara" i konfigureringsmenyn. Om denna väljs så räknas alla fönster om direkt när du sparar dina nya inställningar.
+- **Smart filtrering vid omräkning**: När en manuell omräkning triggas (via knapp eller inställning) filtrerar integrationen nu automatiskt bort priser som redan passerat i tiden. Detta säkerställer att det nya fönstret som väljs alltid ligger i framtiden eller slutar i framtiden.
+
 ## [1.2.6] - 2026-04-02
  
 ### Fixed

--- a/custom_components/tibber-extended/binary_sensor.py
+++ b/custom_components/tibber-extended/binary_sensor.py
@@ -58,6 +58,8 @@ async def async_setup_entry(
     if not coordinator.data:
         await coordinator.async_config_entry_first_refresh()
 
+    force_recalc = hass.data.get("tibber_extended_flags", {}).pop(f"force_recalc_{entry.entry_id}", False)
+
     if coordinator.data:
         for home_id in coordinator.data:
             _LOGGER.info(f"Creating binary sensors for home: {home_id}")
@@ -66,14 +68,14 @@ async def async_setup_entry(
             for span, span_start, span_end in best_spans:
                 entities.append(
                     TibberTargetHoursBinarySensor(
-                        coordinator, home_id, home_name, "best", span, resolution, span_start, span_end
+                        coordinator, home_id, home_name, "best", span, resolution, span_start, span_end, force_recalc
                     )
                 )
 
             # En peak-sensor per hem (som förut)
             entities.append(
                 TibberTargetHoursBinarySensor(
-                    coordinator, home_id, home_name, "peak", peak_target, resolution
+                    coordinator, home_id, home_name, "peak", peak_target, resolution, None, None, force_recalc
                 )
             )
 
@@ -108,10 +110,13 @@ async def async_setup_entry(
 class TibberTargetHoursBinarySensor(RestoreEntity, BinarySensorEntity):
     """Binary sensor for cheapest/most expensive consecutive hours."""
 
-    def __init__(self, coordinator, home_id, home_name, sensor_type, target_hours, resolution, restrict_start=None, restrict_end=None):
-        """Initialize the binary sensor."""
+    def __init__(
+        self, coordinator, home_id, home_name, sensor_type, target_hours, resolution, restrict_start=None, restrict_end=None, force_recalc=False
+    ):
+        """Initialize the target hours binary sensor."""
         self.coordinator = coordinator
         self.home_id = home_id
+        self._init_force_recalc = force_recalc
         self.sensor_type = sensor_type  # "best" or "peak"
         self.target_hours = float(target_hours)
         self.resolution = resolution
@@ -242,6 +247,26 @@ class TibberTargetHoursBinarySensor(RestoreEntity, BinarySensorEntity):
 
         # Kombinera listorna för att kunna hitta fönster som spänner över midnatt
         all_prices = today_prices + tomorrow_prices
+
+        force_update = getattr(self.coordinator, "_force_update", False) or getattr(self, "_init_force_recalc", False)
+
+        # Filtrera bort priser som redan passerat ifall vi har en tvingad omräkning
+        if force_update:
+            from dateutil.parser import isoparse
+            if self.resolution == "QUARTER_HOURLY":
+                pass_delta = timedelta(minutes=15)
+            else:
+                pass_delta = timedelta(hours=1)
+
+            filtered_prices = []
+            for p in all_prices:
+                try:
+                    if isoparse(p["startsAt"]) + pass_delta > now:
+                        filtered_prices.append(p)
+                except Exception:
+                    filtered_prices.append(p)
+            all_prices = filtered_prices
+            self._init_force_recalc = False # Bara utför första gången för options-uppladdningen
 
         if not all_prices:
             return

--- a/custom_components/tibber-extended/button.py
+++ b/custom_components/tibber-extended/button.py
@@ -25,7 +25,10 @@ async def async_setup_entry(
 
     home_name = entry.data.get(CONF_HOME_NAME, "Mitt Hem")
 
-    async_add_entities([TibberRefreshButton(coordinator, home_name)], True)
+    async_add_entities([
+        TibberRefreshButton(coordinator, home_name),
+        TibberRecalculateBestPriceButton(coordinator, home_name)
+    ], True)
     _LOGGER.info("Successfully setup Tibber refresh button")
 
 
@@ -44,3 +47,25 @@ class TibberRefreshButton(ButtonEntity):
         _LOGGER.info("Manuell uppdatering begärd via Refresh-knapp (Bypassar Smart Caching)")
         self.coordinator._force_update = True
         await self.coordinator.async_request_refresh()
+
+
+class TibberRecalculateBestPriceButton(ButtonEntity):
+    """Button to trigger manual recalculation of Best Price windows."""
+
+    def __init__(self, coordinator, home_name):
+        """Initialize the button."""
+        self.coordinator = coordinator
+        self._attr_name = f"{home_name} Re-calculate Best Price"
+        self._attr_unique_id = f"tibber_extended_recalc_{coordinator.entry.entry_id}"
+        self._attr_icon = "mdi:calculator"
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        _LOGGER.info("Manuell omräkning av Best Price begärd via Re-calculate-knapp")
+        orig_force = getattr(self.coordinator, "_force_update", False)
+        self.coordinator._force_update = True
+        try:
+            # Triggar uppdatering för alla listeners (bypassar tidslås och exkluderar passerade priser)
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+        finally:
+            self.coordinator._force_update = orig_force

--- a/custom_components/tibber-extended/config_flow.py
+++ b/custom_components/tibber-extended/config_flow.py
@@ -24,6 +24,8 @@ from .const import (
     DEFAULT_BEST_PRICE_SPANS,
     CONF_USE_SUBUNITS,
     DEFAULT_USE_SUBUNITS,
+    CONF_RECALCULATE_ON_SAVE,
+    DEFAULT_RECALCULATE_ON_SAVE,
     CONF_RESTRICT_TIME_START,
     CONF_RESTRICT_TIME_END,
     DEFAULT_RESTRICT_TIME_START,
@@ -183,6 +185,10 @@ class TibberExtendedOptionsFlow(config_entries.OptionsFlow):
                     if key not in user_input:
                         user_input[key] = ""
 
+                # Kolla om användaren begärt en tvingande omräkning av best price
+                if user_input.pop(CONF_RECALCULATE_ON_SAVE, False):
+                    self.hass.data.setdefault("tibber_extended_flags", {})[f"force_recalc_{self._config_entry.entry_id}"] = True
+
                 # Uppdatera config entry data
                 self.hass.config_entries.async_update_entry(
                     self._config_entry,
@@ -239,6 +245,10 @@ class TibberExtendedOptionsFlow(config_entries.OptionsFlow):
                     CONF_RESTRICT_TIME_END,
                     description={"suggested_value": self._config_entry.data.get(CONF_RESTRICT_TIME_END, DEFAULT_RESTRICT_TIME_END)},
                 ): str,
+                vol.Optional(
+                    CONF_RECALCULATE_ON_SAVE,
+                    default=DEFAULT_RECALCULATE_ON_SAVE,
+                ): bool,
             }
         )
 

--- a/custom_components/tibber-extended/const.py
+++ b/custom_components/tibber-extended/const.py
@@ -23,6 +23,10 @@ DEFAULT_BEST_PRICE_SPANS = "3.0"
 CONF_PRICE_THRESHOLD = "price_threshold"
 DEFAULT_PRICE_THRESHOLD = 0.50
 
+# Recalculate Option
+CONF_RECALCULATE_ON_SAVE = "recalculate_on_save"
+DEFAULT_RECALCULATE_ON_SAVE = False
+
 # Optional Time Restrictions
 CONF_RESTRICT_TIME_START = "restrict_time_start"
 CONF_RESTRICT_TIME_END = "restrict_time_end"

--- a/custom_components/tibber-extended/manifest.json
+++ b/custom_components/tibber-extended/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/adnansarajlic/tibber-extended/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.2.6"
+  "version": "1.2.7"
 }

--- a/custom_components/tibber-extended/sensor.py
+++ b/custom_components/tibber-extended/sensor.py
@@ -300,7 +300,7 @@ class TibberDataCoordinator(DataUpdateCoordinator):
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
-            "User-Agent": "HomeAssistant/Tibber-Extended (1.2.6)",
+            "User-Agent": "HomeAssistant/Tibber-Extended (1.2.7)",
         }
 
         max_attempts = 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,13 @@ class _BinarySensorEntity:
     def async_on_remove(self, func):
         pass
 
+class _ButtonEntity:
+    @property
+    def name(self):
+        return getattr(self, "_attr_name", None)
+    def async_on_remove(self, func):
+        pass
+
 class _RestoreEntity:
     """Stub för RestoreEntity — sparar/återställer state över omstarter."""
     async def async_get_last_state(self):
@@ -73,6 +80,7 @@ sys.modules["homeassistant"] = mock_ha
 sys.modules["homeassistant.components"] = mock_ha.components
 sys.modules["homeassistant.components.sensor"] = mock_ha.components.sensor
 sys.modules["homeassistant.components.binary_sensor"] = mock_ha.components.binary_sensor
+sys.modules["homeassistant.components.button"] = mock_ha.components.button
 sys.modules["homeassistant.helpers.restore_state"] = mock_ha.helpers.restore_state
 sys.modules["homeassistant.config_entries"] = mock_ha.config_entries
 sys.modules["homeassistant.core"] = mock_ha.core
@@ -91,6 +99,7 @@ sys.modules["homeassistant.const"] = mock_ha.const
 mock_ha.components.sensor.SensorEntity = _SensorEntity
 mock_ha.components.sensor.SensorDeviceClass = MagicMock()
 mock_ha.components.binary_sensor.BinarySensorEntity = _BinarySensorEntity
+mock_ha.components.button.ButtonEntity = _ButtonEntity
 mock_ha.helpers.restore_state.RestoreEntity = _RestoreEntity
 mock_ha.helpers.update_coordinator.CoordinatorEntity = _CoordinatorEntity
 mock_ha.helpers.update_coordinator.DataUpdateCoordinator = _DataUpdateCoordinator
@@ -138,3 +147,4 @@ def _load_module(name, filename):
 _load_module("tibber_extended.sensor", "sensor.py")
 _load_module("tibber_extended.binary_sensor", "binary_sensor.py")
 _load_module("tibber_extended.config_flow", "config_flow.py")
+_load_module("tibber_extended.button", "button.py")

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -315,14 +315,14 @@ class TestBestPriceStability:
         )
         sensor.hass = MagicMock()
         sensor.async_on_remove = MagicMock()
-        
+
         # Säkerställ att async_get_last_state inte krashar
         sensor.async_get_last_state = AsyncMock(return_value=None)
         sensor.async_write_ha_state = MagicMock()
-        
+
         with patch("homeassistant.helpers.event.async_track_time_change") as m_track:
             await sensor.async_added_to_hass()
-            
+
             # HOURLY -> ska bara registreras en minut: 0
             m_track.assert_called_once()
             kwargs = m_track.call_args.kwargs

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,100 @@
+"""Tester för button.py och konfigurering."""
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from tibber_extended.button import (
+    async_setup_entry,
+    TibberRefreshButton,
+    TibberRecalculateBestPriceButton,
+)
+from tibber_extended.const import (
+    DOMAIN,
+    CONF_HOME_NAME,
+    CONF_ACCESS_TOKEN,
+    CONF_RECALCULATE_ON_SAVE,
+    CONF_RESTRICT_TIME_START,
+)
+from tibber_extended.config_flow import TibberExtendedOptionsFlow
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Skapa en mock för koordinatorn."""
+    coordinator = MagicMock()
+    coordinator.entry = MagicMock()
+    coordinator.entry.entry_id = "test_entry_id"
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.data = {"test": "data"}
+    coordinator._force_update = False
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_setup_button_platform(mock_coordinator):
+    """Testa plattformens setup-funktion."""
+    mock_hass = MagicMock()
+    mock_hass.data = {DOMAIN: {"test_entry_id": {"coordinator": mock_coordinator}}}
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry_id"
+    mock_entry.data = {CONF_HOME_NAME: "Test Hem"}
+
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(mock_hass, mock_entry, async_add_entities)
+
+    # Verifiera att knappen lades till
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 2
+    # Vi kollar klassnamn för att undvika isinstance-strul med olika modulladdningar
+    assert entities[0].__class__.__name__ == "TibberRefreshButton"
+    assert entities[1].__class__.__name__ == "TibberRecalculateBestPriceButton"
+
+
+@pytest.mark.asyncio
+async def test_refresh_button_press(mock_coordinator):
+    """Testa att Refresh-knappen anropar koordinatorns refresh."""
+    button = TibberRefreshButton(mock_coordinator, "Test Hem")
+    mock_coordinator.async_request_refresh.return_value = None
+    await button.async_press()
+    assert mock_coordinator._force_update is True
+    assert mock_coordinator.async_request_refresh.called
+
+
+@pytest.mark.asyncio
+async def test_recalculate_button_press(mock_coordinator):
+    """Testa att Recalculate-knappen pushar data internt."""
+    button = TibberRecalculateBestPriceButton(mock_coordinator, "Test Hem")
+    mock_coordinator._force_update = False
+    await button.async_press()
+    mock_coordinator.async_set_updated_data.assert_called_once_with({"test": "data"})
+    assert mock_coordinator._force_update is False
+
+
+@pytest.mark.asyncio
+async def test_options_flow_sets_recalculate_flag():
+    """Testa att valet 'recalculate_on_save' sätter en tillfällig flagga i hass.data."""
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry_id"
+    mock_entry.data = {CONF_ACCESS_TOKEN: "valid_token"}
+
+    flow = TibberExtendedOptionsFlow(mock_entry)
+    flow.hass = MagicMock()
+    flow.hass.data = {}
+
+    # Mocka token-validering
+    flow._validate_token = AsyncMock(return_value=True)
+
+    user_input = {
+        CONF_ACCESS_TOKEN: "valid_token",
+        CONF_RECALCULATE_ON_SAVE: True,
+        CONF_RESTRICT_TIME_START: "23:00"
+    }
+
+    await flow.async_step_init(user_input=user_input)
+
+    # Kontrollera att flaggan sattes i hass.data
+    # Eftersom vi använder 'tibber_extended_flags' i koden:
+    assert flow.hass.data["tibber_extended_flags"]["force_recalc_test_entry_id"] is True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -13,7 +13,7 @@ from tibber_extended.const import (
 @pytest.mark.asyncio
 async def test_options_flow_clears_empty_fields():
     """Om användaren tömmer tidsrestriktioner i formuläret ska config uppdateras med tomma strängar."""
-    
+
     # Skapa mock för config entry (befintlig konfig)
     mock_entry = MagicMock()
     mock_entry.data = {
@@ -22,11 +22,11 @@ async def test_options_flow_clears_empty_fields():
         CONF_RESTRICT_TIME_END: "06:00",
         CONF_BEST_PRICE_SPANS: "1, 2, 3",
     }
-    
+
     # Initialisera options flow
     flow = TibberExtendedOptionsFlow(mock_entry)
     flow.hass = MagicMock()
-    
+
     # Mocka token-validering att alltid returnera True
     flow._validate_token = AsyncMock(return_value=True)
 
@@ -39,7 +39,7 @@ async def test_options_flow_clears_empty_fields():
 
     result = await flow.async_step_init(user_input=user_input)
     assert result["type"] == "create_entry"
-    
+
     # Kontrollera vad som HA sparar. '_config_entry.data' MÅSTE ha tomma strängar
     call_kwargs = flow.hass.config_entries.async_update_entry.call_args.kwargs
     new_data = call_kwargs["data"]


### PR DESCRIPTION
Add a new TibberRecalculateBestPriceButton and an options checkbox to trigger immediate recalculation of Best Price windows. When the option is saved a temporary flag is set in hass.data and async_setup_entry passes a force_recalc flag to sensors; the binary sensor logic filters out already-passed price slots when a forced recalculation is requested. Also add tests for the button and options flow, update mocks, bump integration version to 1.2.7, and add changelog notes describing the feature and behavior.